### PR TITLE
Added CRUD for Bugs and Bug_Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-<p align="center">
-# Bugbo: A simplified full-stack Bug Tracking app built using React/Javascript (client-side) and Django/Python (server-side).
-</p>
+<h1 align="center">
+Bugbo: A simplified full-stack Bug Tracking app built using React/Javascript (client-side) and Django/Python (server-side).
+</h1>

--- a/bugbo/urls.py
+++ b/bugbo/urls.py
@@ -14,11 +14,17 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from rest_framework import routers
 from django.conf.urls import include
 from django.urls import path
-from bugboapi.views import register_user, login_user
+from bugboapi.views import register_user, login_user, BugTypeView, BugView
+
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'bugtypes', BugTypeView, 'bugtype')
+router.register(r'bugs', BugView, 'bug')
 
 urlpatterns = [
+    path('', include(router.urls)),
     path('register', register_user),
     path('login', login_user),
     path('api-auth', include('rest_framework.urls', namespace='rest_framework')),

--- a/bugboapi/views/__init__.py
+++ b/bugboapi/views/__init__.py
@@ -1,1 +1,3 @@
 from .auth import login_user, register_user
+from .bug_type import BugTypeView
+from .bug import BugView

--- a/bugboapi/views/bug.py
+++ b/bugboapi/views/bug.py
@@ -1,0 +1,134 @@
+"""View module for handling requests about bugs"""
+from django.core.exceptions import ValidationError
+from rest_framework import status
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from bugboapi.models import Bug, BugType, Employee, BugStatus, BugPriority
+
+class BugView(ViewSet):
+    """Bugbo bugs/tikcets"""
+
+    def create(self, request):
+        """Handle POST operations
+
+        Returns:
+            Response -- JSON serialized bug/ticket instance
+        """
+        # Uses the token passed in the `Authorization` header
+        employee = Employee.objects.get(user=request.auth.user)
+
+        bug_status = BugStatus.objects.get(pk=request.data["status"])
+        bug_priority = BugPriority.objects.get(pk=request.data["priority"])
+        bug_type = BugType.objects.get(pk=request.data["type"])
+
+        # Create a new Python instance of the Bug class
+        # and set its properties from what was sent in the
+        # body of the request from the client.
+        bug = Bug()
+        bug.title = request.data["title"]
+        bug.description = request.data["description"]
+        bug.entry_date = request.data["entry_date"]
+        bug.creator = employee
+        bug.status = bug_status
+        bug.priority = bug_priority
+        bug.type = bug_type
+
+        try:
+            bug.save()
+            serializer = BugSerializer(bug, context={'request': request})
+            return Response(serializer.data)
+        except ValidationError as ex:
+            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single bug/ticket
+
+        Returns:
+            Response -- JSON serialized bug instance
+        """
+        try:
+            # `pk` is a parameter to this function, and
+            # Django parses it from the URL route parameter
+            #   http://localhost:8000/bugs/2
+            #
+            # The `2` at the end of the route becomes `pk`
+            bug = Bug.objects.get(pk=pk)
+            serializer = BugSerializer(bug, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+    def update(self, request, pk=None):
+        """Handle PUT requests for a bug/ticket
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+        employee = Employee.objects.get(user=request.auth.user)
+        bug_status = BugStatus.objects.get(pk=request.data["status"])
+        bug_priority = BugPriority.objects.get(pk=request.data["priority"])
+        bug_type = BugType.objects.get(pk=request.data["type"])
+
+        bug = Bug.objects.get(pk=pk)
+        bug.title = request.data["title"]
+        bug.description = request.data["description"]
+        bug.entry_date = request.data["entry_date"]
+        bug.creator = employee
+        bug.status = bug_status
+        bug.priority = bug_priority
+        bug.type = bug_type
+        bug.save()
+
+        # 204 status code means everything worked but the
+        # server is not sending back any data in the response
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
+    
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single bug/ticket
+
+        Returns:
+            Response -- 200, 404, or 500 status code
+        """
+        try:
+            bug = Bug.objects.get(pk=pk)
+            bug.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except Bug.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def list(self, request):
+        """Handle GET requests to bugs resource
+
+        Returns:
+            Response -- JSON serialized list of bugs
+        """
+        # Get all game records from the database
+        bugs = Bug.objects.all()
+
+        # Support filtering bugs by type
+        #    http://localhost:8000/bugs?type=1
+        type = self.request.query_params.get('type', None) #pylint: disable=redefined-builtin
+        if type is not None:
+            bugs = bugs.filter(type__id=type)
+
+        serializer = BugSerializer(
+            bugs, many=True, context={'request': request})
+        return Response(serializer.data)
+
+class BugSerializer(serializers.ModelSerializer):
+    """JSON serializer for bugs
+
+    Arguments:
+        serializer type
+    """
+    class Meta:
+        model = Bug
+        fields = ('id', 'title', 'description', 'entry_date', 'creator', 'status', 'priority', 'type')
+        depth = 1

--- a/bugboapi/views/bug_type.py
+++ b/bugboapi/views/bug_type.py
@@ -1,0 +1,48 @@
+"""View module for handling requests about bug/ticket types"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from bugboapi.models import BugType
+
+
+class BugTypeView(ViewSet):
+    """Level up bug types"""
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single bug/ticket type
+
+        Returns:
+        Response -- JSON serialized bug/ticket type
+        """
+        try:
+            bug_type = BugType.objects.get(pk=pk)
+            serializer = BugTypeSerializer(bug_type, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+    def list(self, request):
+        """Handle GET requests to get all bug/ticket types
+
+        Returns:
+            Response -- JSON serialized list of bug/ticket types
+        """
+        bug_types = BugType.objects.all()
+
+        # Note the additional `many=True` argument to the
+        # serializer. It's needed when you are serializing
+        # a list of objects instead of a single object.
+        serializer = BugTypeSerializer(
+            bug_types, many=True, context={'request': request})
+        return Response(serializer.data)
+
+class BugTypeSerializer(serializers.ModelSerializer):
+    """JSON serializer for bug/ticket types
+
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = BugType
+        fields = ('id', 'label')

--- a/bugboapi/views/bug_type.py
+++ b/bugboapi/views/bug_type.py
@@ -3,11 +3,29 @@ from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
+from rest_framework import status
+from django.core.exceptions import ValidationError
 from bugboapi.models import BugType
 
 
 class BugTypeView(ViewSet):
     """Level up bug types"""
+
+    def create(self, request):
+        """Handle POST operations
+
+        Returns:
+            Response -- JSON serialized bug_type instance
+        """
+        bug_type = BugType()
+        bug_type.label = request.data["label"]
+
+        try:
+            bug_type.save()
+            serializer = BugTypeSerializer(bug_type, context={'request': request})
+            return Response(serializer.data)
+        except ValidationError as ex:
+            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
 
     def retrieve(self, request, pk=None):
         """Handle GET requests for single bug/ticket type
@@ -36,6 +54,38 @@ class BugTypeView(ViewSet):
         serializer = BugTypeSerializer(
             bug_types, many=True, context={'request': request})
         return Response(serializer.data)
+
+    def update(self, request, pk=None):
+        """Handle PUT requests for a bug types
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+        bug_type = BugType.objects.get(pk=pk)
+        bug_type.label = request.data["label"]
+        bug_type.save()
+
+        # 204 status code means everything worked but the
+        # server is not sending back any data in the response
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single bug_types
+
+        Returns:
+            Response -- 200, 404, or 500 status code
+        """
+        try:
+            bug_type = BugType.objects.get(pk=pk)
+            bug_type.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except BugType.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 class BugTypeSerializer(serializers.ModelSerializer):
     """JSON serializer for bug/ticket types

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,1 +1,52 @@
+Description of PR that completes issue here...
 
+## Changes
+
+- Item 1
+- Item 2
+- Item 3
+
+## Requests / Responses
+
+If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.
+
+**Request**
+
+POST `/products` Creates a new product
+
+```json
+{
+    "title": "Kite",
+    "product_type_id": 1,
+    "description": "Red. It flies high.",
+    "quantity": 5
+}
+```
+
+**Response**
+
+HTTP/1.1 201 OK
+
+```json
+{
+    "id": 54,
+    "title": "Kite",
+    "product_type_id": 1,
+    "description": "Red. It flies high.",
+    "quantity": 5
+}
+```
+
+## Testing
+
+Description of how to test code...
+
+- [ ] Run migrations
+- [ ] Run test suite
+- [ ] Seed database
+
+
+## Related Issues
+
+- Fixes #85
+- Fixes #22


### PR DESCRIPTION
## Changes

- Added `views/bug.py` and `views/bug_type.py` to add basic CRUD functionality for Bugs and Bug_Types


## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/bugs` Creates a new bug/ticket


```json
{
    "title": "This is a test of the creation of a new bug",
    "description": "All users can create tickets. They can represent bugs, tasks, or improvements.",
    "entry_date": "2023-07-07",
    "creator": 7,
    "status": 1,
    "priority":1,
    "type": 1
}
```

POST `/bugtypes` Creates a new bug type

{
"label": "Testing POST request"
}


## Testing

Description of how to test code...

- [ ] Pull this branch and run `./rebuild-database.sh` in terminal
- [ ] Upon completion, in Postman, enter an Authorization Token in the headers
- [ ] Run GET for `http://localhost:8000/bugs` and `http://localhost:8000/bugs/1` and ensure correct response is received
- [ ] Run GET for `http://localhost:8000/bugtypes` and `http://localhost:8000/bugtypes/1` and ensure correct response is received
- [ ] Run GET for `http://localhost:8000/bugs?type=1` to ensure only bugs with a type of 1 are returned
- [ ] Run POST, PUT, and DELETE for `/bugs` and '/bugtypes' and ensure the response is as described.


