### PR TITLE
CRUD added for bug/ticket  statuses

### DIFF
--- a/bugbo/urls.py
+++ b/bugbo/urls.py
@@ -17,11 +17,12 @@ from django.contrib import admin
 from rest_framework import routers
 from django.conf.urls import include
 from django.urls import path
-from bugboapi.views import register_user, login_user, BugTypeView, BugView
+from bugboapi.views import register_user, login_user, BugTypeView, BugView, BugStatusView
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'bugtypes', BugTypeView, 'bugtype')
 router.register(r'bugs', BugView, 'bug')
+router.register(r'bugstatuses', BugStatusView, 'bugstatus')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/bugboapi/views/__init__.py
+++ b/bugboapi/views/__init__.py
@@ -1,3 +1,4 @@
 from .auth import login_user, register_user
 from .bug_type import BugTypeView
 from .bug import BugView
+from .bug_status import BugStatusView

--- a/bugboapi/views/bug_status.py
+++ b/bugboapi/views/bug_status.py
@@ -1,0 +1,98 @@
+"""View module for handling requests about bug/ticket types"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from django.core.exceptions import ValidationError
+from bugboapi.models import BugStatus
+
+
+class BugStatusView(ViewSet):
+    """Bugbo bug status"""
+
+    def create(self, request):
+        """Handle POST operations
+
+        Returns:
+            Response -- JSON serialized bug_status instance
+        """
+        bug_status = BugStatus()
+        bug_status.name = request.data["name"]
+
+        try:
+            bug_status.save()
+            serializer = BugStatusSerializer(bug_status, context={'request': request})
+            return Response(serializer.data)
+        except ValidationError as ex:
+            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single status
+
+        Returns:
+        Response -- JSON serialized status type
+        """
+        try:
+            bug_status = BugStatus.objects.get(pk=pk)
+            serializer = BugStatusSerializer(bug_status, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+    def list(self, request):
+        """Handle GET requests to get all status types
+
+        Returns:
+            Response -- JSON serialized list of status types
+        """
+        bug_statuses = BugStatus.objects.all()
+
+        # Note the additional `many=True` argument to the
+        # serializer. It's needed when you are serializing
+        # a list of objects instead of a single object.
+        serializer = BugStatusSerializer(
+            bug_statuses, many=True, context={'request': request})
+        return Response(serializer.data)
+
+    def update(self, request, pk=None):
+        """Handle PUT requests for a statuses
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+        bug_status = BugStatus.objects.get(pk=pk)
+        bug_status.name = request.data["name"]
+        bug_status.save()
+
+        # 204 status code means everything worked but the
+        # server is not sending back any data in the response
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single statuses
+
+        Returns:
+            Response -- 200, 404, or 500 status code
+        """
+        try:
+            bug_status = BugStatus.objects.get(pk=pk)
+            bug_status.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except BugStatus.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+class BugStatusSerializer(serializers.ModelSerializer):
+    """JSON serializer for status types
+
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = BugStatus
+        fields = ('id', 'name')


### PR DESCRIPTION
CRUD functionality has been added for bug status types i.e. what stage a ticket finds itself in.

## Changes

- Added `views/bug_statuses.py` which includes the code for CRUD
- Added to `BugStatusView` to `bugbo/urls.py` and included routing.


## Testing

Description of how to test code...

- [ ] Pull this branch
- [ ] Run `./rebuild-database.sh` to seed database.
- [ ] Run server
- [ ] In Postman, run a GET to `http://localhost:8000/bugstatuses` and ensure correct response is received. Then run a GET to `http://localhost:8000/bugstatuses/1` to ensure only the status with an id of 1 is returned
- [ ] Copy a single dictionary and run a POST request using `{
"name": "TESTING POST"
}` to `http://localhost:8000/bugstatuses`. Upon running re-run GET all and ensure a new status is created. 
- [ ] Change the POST to a PUT and add the id to the end of the address. i.e. `http://localhost:8000/bugstatuses/1`
- [ ] In the Body add the `"id": 5` then edit the `"name":`
- [ ] Re-run the GET and ensure the edit worked
- [ ] Change that PUT to a DELETE and run
- [ ] Re-run the get and ensure it no longer exists.