### PR TITLE
CRUD added for tags

### DIFF
--- a/bugbo/urls.py
+++ b/bugbo/urls.py
@@ -17,12 +17,13 @@ from django.contrib import admin
 from rest_framework import routers
 from django.conf.urls import include
 from django.urls import path
-from bugboapi.views import register_user, login_user, BugTypeView, BugView, BugStatusView
+from bugboapi.views import register_user, login_user, BugTypeView, BugView, BugStatusView, TagView
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'bugtypes', BugTypeView, 'bugtype')
 router.register(r'bugs', BugView, 'bug')
 router.register(r'bugstatuses', BugStatusView, 'bugstatus')
+router.register(r'bugtags', TagView, 'bugtag')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/bugboapi/views/__init__.py
+++ b/bugboapi/views/__init__.py
@@ -2,3 +2,4 @@ from .auth import login_user, register_user
 from .bug_type import BugTypeView
 from .bug import BugView
 from .bug_status import BugStatusView
+from .tag import TagView

--- a/bugboapi/views/tag.py
+++ b/bugboapi/views/tag.py
@@ -1,0 +1,98 @@
+"""View module for handling requests about bug/ticket types"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from django.core.exceptions import ValidationError
+from bugboapi.models import Tag
+
+
+class TagView(ViewSet):
+    """Bugbo bug/ticket tags"""
+
+    def create(self, request):
+        """Handle POST operations
+
+        Returns:
+            Response -- JSON serialized bug_tag instance
+        """
+        tag = Tag()
+        tag.name = request.data["name"]
+
+        try:
+            tag.save()
+            serializer = TagSerializer(tag, context={'request': request})
+            return Response(serializer.data)
+        except ValidationError as ex:
+            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single tag
+
+        Returns:
+        Response -- JSON serialized tag type
+        """
+        try:
+            tag = Tag.objects.get(pk=pk)
+            serializer = TagSerializer(tag, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+    def list(self, request):
+        """Handle GET requests to get all tag types
+
+        Returns:
+            Response -- JSON serialized list of tag types
+        """
+        tags = Tag.objects.all()
+
+        # Note the additional `many=True` argument to the
+        # serializer. It's needed when you are serializing
+        # a list of objects instead of a single object.
+        serializer = TagSerializer(
+            tags, many=True, context={'request': request})
+        return Response(serializer.data)
+
+    def update(self, request, pk=None):
+        """Handle PUT requests for a tags
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+        tag = Tag.objects.get(pk=pk)
+        tag.name = request.data["name"]
+        tag.save()
+
+        # 204 status code means everything worked but the
+        # server is not sending back any data in the response
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single tags
+
+        Returns:
+            Response -- 200, 404, or 500 status code
+        """
+        try:
+            tag = Tag.objects.get(pk=pk)
+            tag.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except Tag.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+class TagSerializer(serializers.ModelSerializer):
+    """JSON serializer for tag types
+
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = Tag
+        fields = ('id', 'name')


### PR DESCRIPTION
CRUD functionality was added for ticket tags.

## Changes

- Added `views/tag.py` housing the crud functions
- Added to `bugbo/urls/py` the route for the TagView `bugtags`

## Testing

Description of how to test code...

- [ ] Pull this branch
- [ ]  Run `./rebuild-database.sh` to seed database.
- [ ]  Run server
- [ ]  In Postman, run a GET to `http://localhost:8000/bugtags` and ensure correct response is received. Then run a GET to `http://localhost:8000/bugtags/1` to ensure only the status with an id of 1 is returned
- [ ]  Copy a single dictionary and run a POST request using `{ "name": "TESTING POST" }` to `http://localhost:8000/bugtags`. Upon running re-run GET all and ensure a new status is created.
- [ ]  Change the POST to a PUT and add the id to the end of the address. i.e. `http://localhost:8000/bugtags/5`
- [ ]  In the Body add the `"id": 5` then edit the `"name": "Change This"`
- [ ]  Re-run the GET and ensure the edit worked
- [ ]  Change that PUT to a DELETE and run
- [ ]  Re-run the get and ensure it no longer exists.