### PR TITLE
CRUD added for bug priority

### DIFF
--- a/bugbo/urls.py
+++ b/bugbo/urls.py
@@ -17,13 +17,14 @@ from django.contrib import admin
 from rest_framework import routers
 from django.conf.urls import include
 from django.urls import path
-from bugboapi.views import register_user, login_user, BugTypeView, BugView, BugStatusView, TagView
+from bugboapi.views import register_user, login_user, BugTypeView, BugView, BugStatusView, TagView, BugPriorityView
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'bugtypes', BugTypeView, 'bugtype')
 router.register(r'bugs', BugView, 'bug')
 router.register(r'bugstatuses', BugStatusView, 'bugstatus')
 router.register(r'bugtags', TagView, 'bugtag')
+router.register(r'bugpriorities', BugPriorityView, 'bugpriority')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/bugboapi/views/__init__.py
+++ b/bugboapi/views/__init__.py
@@ -3,3 +3,4 @@ from .bug_type import BugTypeView
 from .bug import BugView
 from .bug_status import BugStatusView
 from .tag import TagView
+from .bug_priority import BugPriorityView

--- a/bugboapi/views/bug_priority.py
+++ b/bugboapi/views/bug_priority.py
@@ -1,0 +1,98 @@
+"""View module for handling requests about bug/ticket types"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from django.core.exceptions import ValidationError
+from bugboapi.models import BugPriority, bug_priority
+
+
+class BugPriorityView(ViewSet):
+    """Level up bug priorities"""
+
+    def create(self, request):
+        """Handle POST operations
+
+        Returns:
+            Response -- JSON serialized bug_priority instance
+        """
+        bug_priority = BugPriority()
+        bug_priority.label = request.data["label"]
+
+        try:
+            bug_priority.save()
+            serializer = BugPrioritySerializer(bug_priority, context={'request': request})
+            return Response(serializer.data)
+        except ValidationError as ex:
+            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single bug_priority
+
+        Returns:
+        Response -- JSON serialized bug_priority
+        """
+        try:
+            bug_priority = BugPriority.objects.get(pk=pk)
+            serializer = BugPrioritySerializer(bug_priority, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+    def list(self, request):
+        """Handle GET requests to get all bug_priority
+
+        Returns:
+            Response -- JSON serialized list of bug_priority
+        """
+        bug_priorities = BugPriority.objects.all()
+
+        # Note the additional `many=True` argument to the
+        # serializer. It's needed when you are serializing
+        # a list of objects instead of a single object.
+        serializer = BugPrioritySerializer(
+            bug_priorities, many=True, context={'request': request})
+        return Response(serializer.data)
+
+    def update(self, request, pk=None):
+        """Handle PUT requests for a bug priorities
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+        bug_priority = BugPriority.objects.get(pk=pk)
+        bug_priority.label = request.data["label"]
+        bug_priority.save()
+
+        # 204 status code means everything worked but the
+        # server is not sending back any data in the response
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single bug priority
+
+        Returns:
+            Response -- 200, 404, or 500 status code
+        """
+        try:
+            bug_priority = BugPriority.objects.get(pk=pk)
+            bug_priority.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except BugPriority.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+class BugPrioritySerializer(serializers.ModelSerializer):
+    """JSON serializer for bug priorities
+
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = BugPriority
+        fields = ('id', 'label')


### PR DESCRIPTION
The bug-priority labels how important certain bugs/tickets are in terms of need. They now have CRUD functionality that will be used by the admin class if need be.

## Changes

- Added `views/bug_priority.py` which houses all the crud functions
- Added routing to `bugbo/urls.py`


## Testing

Description of how to test code...

- [ ]  Pull this branch
- [ ]  Run `./rebuild-database.sh` to seed database.
- [ ]  Run server
- [ ]  In Postman, run a GET to `http://localhost:8000/bugpriorities` and ensure correct response is received. Then run a GET to `http://localhost:8000/bugprioritiess/1` to ensure only the status with an id of 1 is returned
- [ ]  Copy a single dictionary and run a POST request using `{ "label": "TESTING POST" }` to `http://localhost:8000/bugpriorities`. Upon running re-run GET all and ensure a new status is created.
- [ ]  Change the POST to a PUT and add the id to the end of the address. i.e. `http://localhost:8000/bugpriorities/5`
- [ ]  In the Body add the `"id": 5` then edit the `"label": "Change This"`
- [ ]  Re-run the GET and ensure the edit worked
- [ ]  Change that PUT to a DELETE and run
- [ ]  Re-run the GET and ensure it no longer exists.